### PR TITLE
SEC-4616: Leapp setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # leapp-setup
+This repo contains setup and installation scripts for [Leapp](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2847113303/Leapp).  Leapp is used to manage AWS SSO credentials locally.
+
+These scripts are made publicly available in order to allow CX members to execute them without github accounts.
+
+## Setup
+This script sets up a Leapp integration and its dependencies.  This script requires having the Leapp desktop application already installed ([download here](https://www.leapp.cloud/releases)).  This script performs the following:
+
+- Installs the xcode Command Line Tools
+- Ensures Homebrew is installed and installs Python and the AWS CLI
+- Installs the AWS Session Manger Plugin, which is required when using AWS SSO in Leapp
+- Installs the Leapp CLI
+- Sets up an integration with Panorama's AWS SSO environment
+- Renames the profiles for select AWS roles so that they match their role name.  This allows for us to provide more consistent instructions for using Filezilla & using AWS SSO in local development environments.
+
+This script expects an AWS SSO portal URL and a list of "|" separated roles to have their profile name renamed.  The full command to run this script is available on Panopedia on the the [Leapp Panopedia page](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2847113303/Leapp) for Engineering & CX to copy and paste and includes all necessary variables.  We only publish this on Panopedia to avoid publicly exposing these internal details.
+
+# Rollback Setup
+This script is only meant for testing and is used to revert the setup script in order to run it again.  It does not require any variables as input.

--- a/rollback_setup.sh
+++ b/rollback_setup.sh
@@ -1,0 +1,22 @@
+while true; do
+    read -p "Running this script will uninstall the Leapp CLI, Homebrew, and xcode Command Line Tools. It is meant to revert the setup.sh for testing it.  Do you wish to continue? [Yes / No] " yn
+    case $yn in
+        [Yy]* ) break;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+# Uninstall Leapp CLI
+brew uninstall Noovolari/brew/leapp-cli
+# Uninstall Session Manager Plugin
+sudo rm -rf /usr/local/sessionmanagerplugin
+sudo rm /usr/local/bin/session-manager-plugin
+# Uninstall AWS CLI
+brew uninstall awscli
+# Uninstall python
+brew uninstall python --ignore-dependencies python
+# Uninstall homebrew
+sudo /bin/bash -cf "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+# Uninstall xcode
+sudo rm -rf /Library/Developer/CommandLineTools

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,115 @@
+if [[ -z "${INTEGRATION_PORTAL_URL}" ]]; then
+    echo "INTEGRATION_PORTAL_URL must be provided"
+    exit
+fi
+
+if [[ -z "${LEAPP_ROLES}" ]]; then
+    echo "LEAPP_ROLES must be provided"
+    exit
+fi
+
+# Install the xcode Command Line Tools, if they are not installed
+xcode-select --install
+
+# Install Homebrew if not installed
+which -s brew
+if [[ $? != 0 ]] ; then
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" </dev/null
+fi
+
+# The AWS CLI requires python
+brew install python
+# The AWS credential files require the AWS CLI to be installed
+brew install awscli
+
+# If using an M1 machine, add a symlink for the AWS credential files to where Leapp expects them
+if [[ ! -f /usr/local/bin/aws ]]; then
+    ln -s /opt/homebrew/bin/aws /usr/local/bin/aws
+fi
+
+# For the app store version of filezilla, it expects the .aws credentials
+# to be in the filezilla installation directory.  Add a symlink there.
+ln -s ~/.aws ~/Library/Containers/org.filezilla-project.filezilla.sandbox/Data/.aws
+
+# Install session manager plugin
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip" -o "sessionmanager-bundle.zip"
+unzip -o sessionmanager-bundle.zip
+python3 sessionmanager-bundle/install -i /usr/local/sessionmanagerplugin -b /usr/local/bin/session-manager-plugin
+rm -rf sessionmanager-bundle
+
+brew install Noovolari/brew/leapp-cli
+
+# Leapp integration setup
+LEAPP=/Applications/Leapp.app
+
+# Check if Leapp is installed
+if [ -d "$LEAPP" ]; then
+    # If Leapp is not running, open it and wait for it to start up
+    if ! pgrep -x Leapp &>/dev/null; then
+        open $LEAPP
+        sleep 5
+    fi
+
+    # If there's no Panorama integration, set it up
+    if ! leapp integration list --no-header | grep -i Panorama; then
+        leapp integration create \
+            --integrationType AWS-SSO \
+            --integrationAlias Panorama \
+            --integrationPortalUrl $INTEGRATION_PORTAL_URL \
+            --integrationRegion us-east-1
+    fi
+
+    PANORAMA_INTEGRATION=$(
+        leapp integration list --csv --columns=ID,"Integration Name","Status" \
+        | grep Panorama
+    )
+
+    INTEGRATION_ID=$(echo $PANORAMA_INTEGRATION | awk -F$',' '{print $1;}')
+    INTEGRATION_STATUS=$(echo $PANORAMA_INTEGRATION | awk -F$',' '{print $3;}')
+
+    if [[ $INTEGRATION_STATUS == "Offline" ]]; then
+        leapp integration login --integrationId $INTEGRATION_ID
+    fi
+
+    function set_profile_id() {
+        PROFILE_ID=$(
+            leapp profile list --csv --columns=ID,'Profile Name' \
+            | grep $ROLE_NAME \
+            | awk  -F$',' '{print $1;}'
+        )
+    }
+
+    AVAILABLE_LEAPP_SESSIONS=$(
+        leapp session list --csv --columns=id,role |
+        grep -E $LEAPP_ROLES
+    )
+
+    while IFS= read -r line; do
+        SESSION_ID=$(echo $line | awk  -F$',' '{print $1;}')
+        ROLE_NAME=$(echo $line | awk -F$',' '{print $2;}')
+
+        echo "Creating $ROLE_NAME profile"
+
+        set_profile_id
+
+        # If the role's name is not in the list of existing profiles, create it.
+        if [ -z "$PROFILE_ID" ]; then
+            leapp profile create --profileName $ROLE_NAME
+
+            set_profile_id
+        fi
+
+        # Associate the session with the profile matching the role.
+        leapp session change-profile --profileId $PROFILE_ID --sessionId $SESSION_ID
+    done <<< "$AVAILABLE_LEAPP_SESSIONS"
+
+    # If we found at least one available session, then we can presume
+    # this installation was successful.
+    if (( $(echo "$AVAILABLE_LEAPP_SESSIONS" | wc -l) > 10 )); then
+        echo "+++++ Installation successful. +++++"
+    else
+        echo "----- Error during installation.  Please share the above output to the Infra/Ops Zone. -----"
+    fi
+else
+    echo "Leapp has not been installed."
+fi


### PR DESCRIPTION
See the video posted on the `Leapp` Panopedia page for a video of this installation.  Further description of these scripts are on the `Leapp Setup Repo` Panopedia page.

* Removed the Panorama integration in Leapp
* Ran the uninstallation script: `eval "$(curl -Ls https://raw.githubusercontent.com/panorama-ed/leapp-setup/SEC-4616-Leapp-setup-scripts/uninstall.sh)"` to remove the Leapp CLI and all dependencies
* Ran the setup script: `INTEGRATION_PORTAL_URL=... LEAPP_ROLES=... eval "$(curl -Ls https://raw.githubusercontent.com/panorama-ed/leapp-setup/SEC-4616-Leapp-setup-scripts/setup.sh)"` which successfully completed
* Verified that I could run sessions in Leapp
* Verified that I could use the SFTP profiles in FIlezilla to access the SFTP bucket.