### PR TITLE
SCALE-293: script setup for kubectl access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,43 @@
 # leapp-setup
-This repo contains setup and installation scripts for [Leapp](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2847113303/Leapp).  Leapp is used to manage AWS SSO credentials locally.
 
-These scripts are made publicly available in order to allow CX members to execute them without github accounts.
+This repo contains setup and installation scripts for [Leapp](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2847113303/Leapp).
+Leapp is used to manage AWS SSO credentials locally.
+
+These scripts are made publicly available in order to allow CX members to
+execute them without github accounts.
 
 ## Setup
-This script sets up a Leapp integration and its dependencies.  This script requires having the Leapp desktop application already installed ([download here](https://www.leapp.cloud/releases)).  This script performs the following:
+
+This script sets up a Leapp integration and its dependencies.  This script
+requires having the Leapp desktop application already installed ([download here](https://www.leapp.cloud/releases)).
+This script performs the following:
 
 - Installs the xcode Command Line Tools
 - Ensures Homebrew is installed and installs Python and the AWS CLI
-- Installs the AWS Session Manger Plugin, which is required when using AWS SSO in Leapp
+- Installs the AWS Session Manger Plugin, which is required when using AWS SSO
+  in Leapp
 - Installs the Leapp CLI
 - Sets up an integration with Panorama's AWS SSO environment
-- Renames the profiles for select AWS roles so that they match their role name.  This allows for us to provide more consistent instructions for using Filezilla & using AWS SSO in local development environments.
+- Renames the profiles for select AWS roles so that they match their role name.
+  This allows for us to provide more consistent instructions for using
+  Filezilla & using AWS SSO in local development environments.
 
-This script expects an AWS SSO portal URL and a list of "|" separated roles to have their profile name renamed.  The full command to run this script is available on Panopedia on the the [Leapp Panopedia page](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2847113303/Leapp) for Engineering & CX to copy and paste and includes all necessary variables.  We only publish this on Panopedia to avoid publicly exposing these internal details.
+This script expects an AWS SSO portal URL and a list of "|" separated roles to
+have their profile name renamed.  The full command to run this script is
+available on Panopedia on the the [Leapp Panopedia page](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2847113303/Leapp)
+for Engineering & CX to copy and paste and includes all necessary variables.
+We only publish this on Panopedia to avoid publicly exposing these internal details.
 
-# Rollback Setup
-This script is only meant for testing and is used to revert the setup script in order to run it again.  It does not require any variables as input.
+## Rollback Setup
+
+This script is only meant for testing and is used to revert the setup script in
+order to run it again.  It does not require any variables as input.
+
+## Create K8s Chained Session Setup
+
+This script is meant to create the chained IAM Role sessions using the
+`TerraformRole` in each of our K8s cluster accounts.  These sessions
+enable the use of kubectl with the clusters.  Further instructions
+and information can be found in the [Working With Clusters](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2891415801/Working+with+Clusters)
+KB in Panopedia.
+

--- a/create-k8s-chained-sessions.sh
+++ b/create-k8s-chained-sessions.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Usage
+# This script takes no arguments.
+# Execute this script after doing your initial setup to automatically generate
+# the sessions necessary for working with kubectl.
+# Do not run this script more than once without resetting your Leapp
+# instance beforehand.
+
+# global variables
+declare K8S_PROFILE_ID
+declare CHAINED_PROFILE_IDS="name,id\n"
+declare REGION='us-east-1'
+
+###### FUNCTIONS ######
+#
+# function to create a chained leapp session given a parent session id
+# Args:
+# 1: parent session id name from leapp
+# appends new session id from the new chained session to CHAINED_PROFILE_IDS
+function createLeappSession() {
+    parent_session_name=$1
+    chained_session_name="chained-from-${parent_session_name}"
+    echo "starting session for ${parent_session_name} to get role arn"
+    # this has funky piping because `--filter` is a fuzzy lookup and `panorama-k8s-playground` fuzzy matches `panorama-k8s-playground-2` as the first result
+    parent_session_id=$(leapp session list -x --filter="Session Name=${parent_session_name}" --no-header | sort -k1 -r | sed -n 1p | awk '{print $1}')
+    # start leapp session
+    leapp session start --sessionId $parent_session_id
+    # call to aws to get the role arn for `TerraformRole`
+    role_arn=$(aws iam get-role --role-name TerraformRole --query Role.Arn | tr -d '"')
+    # stop the leapp session
+    leapp session stop --sessionId $parent_session_id
+
+    echo "creating new session"
+    # create new chained leapp session from parent
+    leapp session add --providerType aws --sessionType awsIamRoleChained \
+        --sessionName $chained_session_name --region $REGION \
+        --roleArn $role_arn --parentSessionId $parent_session_id \
+        --profileId $K8S_PROFILE_ID
+    # add session id from the new session to CHAINED_PROFILE_IDS
+    chained_session_id=$(leapp session list --columns=ID --filter="Session Name=${chained_session_name}" --no-header)
+    CHAINED_PROFILE_IDS="${CHAINED_PROFILE_IDS}${chained_session_name},${chained_session_id}\n"
+}
+
+# function to create a leapp profile to associate with the chained k8s sessions
+# stores the new profile id in K8S_PROFILE_ID
+function createLeappProfile() {
+    leapp profile create --profileName kubectl-access-role
+    K8S_PROFILE_ID=$(leapp profile list --columns=ID --filter="Profile Name=kubectl-access-role" --no-header)
+}
+#
+###### END FUNCTIONS ######
+
+echo "Creating Leapp Profile for use with chained k8s sessions"
+createLeappProfile
+echo "new profile id: ${K8S_PROFILE_ID}"
+
+echo "Creating Leapp Chained k8s sessions for k8s accounts"
+# session names from Leapp for each k8s account
+PARENT_SESSION_NAMES="panorama-k8s-playground panorama-k8s-playground-2 panorama-k8-integration panorama-k8s-staging panorama-k8s-production"
+
+for session in $PARENT_SESSION_NAMES
+do
+    createLeappSession $session
+done
+
+echo "all sessions created. store IDs for future use:"
+echo -e $CHAINED_PROFILE_IDS


### PR DESCRIPTION
Add a script to setup the chained iam role sessions in leapp for our k8s accounts. These are the sessions that are used when accessing the cluster api with kubectl.