### PR TITLE
Set the minimum OS Version to 12.4.0

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,13 @@
+# xcode command line tools installation will hang on OS versions lower than this
+MIN_OS_VERSION="12.4.0"
+CURRENT_OS_VERSION=$(sw_vers -productVersion)
+
+# use version sorting to check if the current version is less than $MIN_OS_VERSION
+if [[ $MIN_OS_VERSION != "$(printf "$MIN_OS_VERSION\n$CURRENT_OS_VERSION" | sort -V | sed -n 1p)" ]]; then
+    echo "MacOS minimum required version is ${MIN_OS_VERSION}. The installed version is ${CURRENT_OS_VERSION}. Please update your OS before running this script."
+    exit
+fi
+
 if [[ -z "${INTEGRATION_PORTAL_URL}" ]]; then
     echo "INTEGRATION_PORTAL_URL must be provided"
     exit


### PR DESCRIPTION
add a check to ensure the OS is >= 12.4.0 based on the experience of users that xcode command line tools cannot be installed if the OS version is below that.