### PR TITLE
Use Unique Named Profiles for Chained K8s Sessions

### DIFF
--- a/create-k8s-chained-sessions.sh
+++ b/create-k8s-chained-sessions.sh
@@ -7,8 +7,8 @@
 # instance beforehand.
 
 # global variables
-declare K8S_PROFILE_ID
-declare CHAINED_PROFILE_IDS="name,id\n"
+declare PROFILE_ID
+declare CHAINED_SESSION_IDS="name,id\n"
 declare REGION='us-east-1'
 
 ###### FUNCTIONS ######
@@ -16,13 +16,13 @@ declare REGION='us-east-1'
 # function to create a chained leapp session given a parent session id
 # Args:
 # 1: parent session id name from leapp
-# appends new session id from the new chained session to CHAINED_PROFILE_IDS
-function createLeappSession() {
+# appends new session id from the new chained session to CHAINED_SESSION_IDS
+function createLeappSession {
     parent_session_name=$1
     chained_session_name="chained-from-${parent_session_name}"
     echo "starting session for ${parent_session_name} to get role arn"
     # this has funky piping because `--filter` is a fuzzy lookup and `panorama-k8s-playground` fuzzy matches `panorama-k8s-playground-2` as the first result
-    parent_session_id=$(leapp session list -x --filter="Session Name=${parent_session_name}" --no-header | sort -k1 -r | sed -n 1p | awk '{print $1}')
+    parent_session_id=$(leapp session list -x --filter="Session Name=${parent_session_name}" --no-header | sort -k2 | sed -n 1p | awk '{print $1}')
     # start leapp session
     leapp session start --sessionId $parent_session_id
     # call to aws to get the role arn for `TerraformRole`
@@ -30,33 +30,34 @@ function createLeappSession() {
     # stop the leapp session
     leapp session stop --sessionId $parent_session_id
 
+    # create a named profile per account so they can be used simultaneously
+    echo "creating new profile"
+    createLeappProfile $parent_session_name
+
     echo "creating new session"
     # create new chained leapp session from parent
     leapp session add --providerType aws --sessionType awsIamRoleChained \
         --sessionName $chained_session_name --region $REGION \
         --roleArn $role_arn --parentSessionId $parent_session_id \
-        --profileId $K8S_PROFILE_ID
-    # add session id from the new session to CHAINED_PROFILE_IDS
+        --profileId $PROFILE_ID
+    # add session id from the new session to CHAINED_SESSION_IDS
     chained_session_id=$(leapp session list --columns=ID --filter="Session Name=${chained_session_name}" --no-header)
-    CHAINED_PROFILE_IDS="${CHAINED_PROFILE_IDS}${chained_session_name},${chained_session_id}\n"
+    CHAINED_SESSION_IDS="${CHAINED_SESSION_IDS}${chained_session_name},${chained_session_id}\n"
 }
 
 # function to create a leapp profile to associate with the chained k8s sessions
-# stores the new profile id in K8S_PROFILE_ID
-function createLeappProfile() {
-    leapp profile create --profileName kubectl-access-role
-    K8S_PROFILE_ID=$(leapp profile list --columns=ID --filter="Profile Name=kubectl-access-role" --no-header)
+# stores the new profile id in PROFILE_ID
+function createLeappProfile {
+    profile_name="kubectl-access-role-${1}"
+    leapp profile create --profileName $profile_name
+    PROFILE_ID=$(leapp profile list --columns=ID --filter="Profile Name=${profile_name}" --no-header)
 }
 #
 ###### END FUNCTIONS ######
 
-echo "Creating Leapp Profile for use with chained k8s sessions"
-createLeappProfile
-echo "new profile id: ${K8S_PROFILE_ID}"
-
 echo "Creating Leapp Chained k8s sessions for k8s accounts"
 # session names from Leapp for each k8s account
-PARENT_SESSION_NAMES="panorama-k8s-playground panorama-k8s-playground-2 panorama-k8-integration panorama-k8s-staging panorama-k8s-production"
+PARENT_SESSION_NAMES="panorama-k8s-playground panorama-k8s-playground-2 panorama-k8s-integration panorama-k8s-staging panorama-k8s-production"
 
 for session in $PARENT_SESSION_NAMES
 do
@@ -64,4 +65,4 @@ do
 done
 
 echo "all sessions created. store IDs for future use:"
-echo -e $CHAINED_PROFILE_IDS
+echo -e $CHAINED_SESSION_IDS


### PR DESCRIPTION
update script to create k8s chained sessions to use unique profile names for each session so they can be started simultaneously for easier cluster switching.

After running the script, I have the 5 chained sessions:
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/7363962/208503243-cd1ce308-bb47-48a1-8f31-53e2da2b0b57.png">

and 5 corresponding Named Profiles:
<img width="523" alt="image" src="https://user-images.githubusercontent.com/7363962/208503401-c20d75dd-70a8-4716-991f-c51b6cc4411a.png">
