### PR TITLE
IOPZ-1445 Make create-k8s-chained-sessions.sh idempotent

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 MIN_OS_VERSION="12.4.0"
 CURRENT_OS_VERSION=$(sw_vers -productVersion)
 
-red_echo () { echo -ne "\033[1;31m"; echo -n "$@"; echo -e "\033[0m"; }
+. ./utils.sh
 
 # use version sorting to check if the current version is less than $MIN_OS_VERSION
 if [[ $MIN_OS_VERSION != "$(printf "$MIN_OS_VERSION\n$CURRENT_OS_VERSION" | sort -V | sed -n 1p)" ]]; then

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# A collection of utility functions to be sourced by other scripts
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+red_echo () { echo -e "${RED}$*${NC}"; }
+green_echo () { echo -e "${GREEN}$*${NC}"; }
+yellow_echo () { echo -e "${YELLOW}$*${NC}"; }
+
+logStdErr() {
+    while read -r line; do
+        red_echo "$line" >&2
+    done
+}


### PR DESCRIPTION
This commit makes the `create-k8s-chained-sessions.sh` script idempotent (it no longer breaks or behaves weirdly if some or all chained sessions already exist). In addition, it tidies up some aspects of the script, removes unnecessary output, and makes improvements so the script now passes the ShellCheck linter.