### PR TITLE
Iopz 2276 update create k8s chained sessions script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ We only publish this on Panopedia to avoid publicly exposing these internal deta
 This script is only meant for testing and is used to revert the setup script in
 order to run it again.  It does not require any variables as input.
 
-## Create K8s Chained Session Setup
+## Create Chained Session Setup
 
 This script is meant to create the chained IAM Role sessions using the
-`TerraformRole` in each of our K8s cluster accounts.  These sessions
+`TerraformRole` in each of our K8s and DBs cluster accounts.  These sessions
 enable the use of kubectl with the clusters.  Further instructions
 and information can be found in the [Working With Clusters](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2891415801/Working+with+Clusters)
 KB in Panopedia.


### PR DESCRIPTION
This change updates and renames the create-k8s-chained-sessions.sh script to create-chained-sessions.sh after including chained sessions that relate to the DB AWS accounts. These new chained sessions will be used for the new start-db-bastion command, which starts SSM sessions using these new leapp sessions to connect to Bastion hosts in the DB AWS accounts.

This script was tested by running it in playground and playground-2 after I applied TF changes to the IAM roles from this [PR](https://github.com/panorama-ed/nds-terraform/pull/185)