### PR TITLE
SECZ-1467: Add new SSO role for chained sessions

### DIFF
--- a/create-chained-sessions.sh
+++ b/create-chained-sessions.sh
@@ -105,3 +105,7 @@ do
     createLeappSession "$env" "DBs" "PanoramaDBsEngineeringDefault" "panorama" "dev-writer"
     createLeappSession "$env" "DBs" "PanoramaDBsEngineeringDefault" "panorama" "dev-reader"
 done
+
+# session names from Leapp for production only
+createLeappSession "production" "DBs" "PanoramaDBsProdAccess" "panorama" "dev-writer"
+createLeappSession "production" "DBs" "PanoramaDBsProdAccess" "panorama" "dev-reader"


### PR DESCRIPTION
## Proposed changes

Add new `PanoramaDBsProdAccess` SSO role that can assume dev-reader and dev-writer for prod DB access.

## Manual testing

```
❯ ./create-chained-sessions.sh

...

creating chained session for production with persona dev-writer
    looking for existing session DBs-production-dev-writer
    existing session found
creating chained session for production with persona dev-reader
    looking for existing session DBs-production-dev-reader
    existing session found
```